### PR TITLE
Add `logger_name` option

### DIFF
--- a/example.py
+++ b/example.py
@@ -30,11 +30,14 @@ def main(directory):
         variables=[args, args.paths],
         verbose=verbose,
         timestamp=True,
+        logger_name="my_logger"
     )
 
-    logging.info("This is an info message")
-    logging.debug("This is a debug message")
-    logging.warning("This fun logging experience is about to end :(")
+    logger = logging.getLogger("my_logger")
+
+    logger.info("This is an info message")
+    logger.debug("This is a debug message")
+    logger.warning("This fun logging experience is about to end :(")
 
 
 if __name__ == "__main__":

--- a/example.py
+++ b/example.py
@@ -30,7 +30,7 @@ def main(directory):
         variables=[args, args.paths],
         verbose=verbose,
         timestamp=True,
-        logger_name="my_logger"
+        logger_name="my_logger",
     )
 
     logger = logging.getLogger("my_logger")

--- a/fancylog/fancylog.py
+++ b/fancylog/fancylog.py
@@ -37,7 +37,7 @@ def start_logging(
     log_to_file=True,
     log_to_console=True,
     timestamp=True,
-    logger_name=False,
+    logger_name=None,
 ):
     """Prepares the log file, and then begins logging.
 
@@ -62,7 +62,7 @@ def start_logging(
     terminal.
     :param log_to_console: Print logs to the console or not: Default: True
     :param timestamp: If True, add a timestamp to the filename
-    :param logger_name: If False, logger uses default logger. Otherwise,
+    :param logger_name: If None, logger uses default logger. Otherwise,
         logger name is set to `logger_name`.
     :return: Path to the logging file#
     """
@@ -229,7 +229,7 @@ def initialise_logger(
     print_level="INFO",
     file_level="DEBUG",
     log_to_console=True,
-    logger_name=False,
+    logger_name=None,
 ):
     """Sets up (possibly multiprocessing aware) logging.
     :param filename: Where to save the logs to
@@ -238,6 +238,8 @@ def initialise_logger(
     :param file_level: What level of logging to print to file.
     Default: 'DEBUG'
     :param log_to_console: Print logs to the console or not
+    :param logger_name: If None, logger uses default logger. Otherwise,
+    logger name is set to `logger_name`.
     """
     if logger_name:
         logger = logging.getLogger(logger_name)
@@ -274,7 +276,7 @@ def setup_logging(
     file_level="DEBUG",
     multiprocessing_aware=True,
     log_to_console=True,
-    logger_name=False,
+    logger_name=None,
 ):
     """Sets up (possibly multiprocessing aware) logging.
     :param filename: Where to save the logs to
@@ -285,7 +287,8 @@ def setup_logging(
     :param multiprocessing_aware: Default: True
     :param log_to_console: Print logs to the console or no.
     Default: True
-
+    :param logger_name: If None, logger uses default logger. Otherwise,
+        logger name is set to `logger_name`.
     """
     initialise_logger(
         filename,

--- a/fancylog/fancylog.py
+++ b/fancylog/fancylog.py
@@ -37,6 +37,7 @@ def start_logging(
     log_to_file=True,
     log_to_console=True,
     timestamp=True,
+    logger_name=False,
 ):
     """Prepares the log file, and then begins logging.
 
@@ -59,8 +60,10 @@ def start_logging(
     Default: True
     :param log_to_file: If True, write a log file, otherwise just print to
     terminal.
-    :param timestamp: If True, add a timestamp to the filename
     :param log_to_console: Print logs to the console or not: Default: True
+    :param timestamp: If True, add a timestamp to the filename
+    :param logger_name: If False, logger uses default logger. Otherwise,
+        logger name is set to `logger_name`.
     :return: Path to the logging file#
     """
     output_dir = str(output_dir)
@@ -98,6 +101,7 @@ def start_logging(
         file_level=file_log_level,
         multiprocessing_aware=multiprocessing_aware,
         log_to_console=log_to_console,
+        logger_name=logger_name,
     )
     return logging_file
 
@@ -225,6 +229,7 @@ def initialise_logger(
     print_level="INFO",
     file_level="DEBUG",
     log_to_console=True,
+    logger_name=False,
 ):
     """Sets up (possibly multiprocessing aware) logging.
     :param filename: Where to save the logs to
@@ -234,7 +239,11 @@ def initialise_logger(
     Default: 'DEBUG'
     :param log_to_console: Print logs to the console or not
     """
-    logger = logging.getLogger()
+    if logger_name:
+        logger = logging.getLogger(logger_name)
+    else:
+        logger = logging.getLogger()
+
     logger.setLevel(getattr(logging, file_level))
 
     formatter = logging.Formatter(
@@ -265,6 +274,7 @@ def setup_logging(
     file_level="DEBUG",
     multiprocessing_aware=True,
     log_to_console=True,
+    logger_name=False,
 ):
     """Sets up (possibly multiprocessing aware) logging.
     :param filename: Where to save the logs to
@@ -282,6 +292,7 @@ def setup_logging(
         print_level=print_level,
         file_level=file_level,
         log_to_console=log_to_console,
+        logger_name=logger_name,
     )
     if multiprocessing_aware:
         try:

--- a/tests/tests/test_general.py
+++ b/tests/tests/test_general.py
@@ -1,5 +1,6 @@
-import fancylog
 import logging
+
+import fancylog
 
 lateral_separator = "**************"
 
@@ -31,11 +32,9 @@ def test_logger_name(tmp_path):
     logger_name = "hello_world"
 
     # Logger name should not already exist
-    assert logger_name not in logging.root.manager.loggerDict.keys()
+    assert logger_name not in logging.root.manager.loggerDict
 
     # Logger name should be created
     fancylog.start_logging(tmp_path, fancylog, logger_name=logger_name)
 
-    assert logger_name in logging.root.manager.loggerDict.keys()
-
-
+    assert logger_name in logging.root.manager.loggerDict

--- a/tests/tests/test_general.py
+++ b/tests/tests/test_general.py
@@ -1,4 +1,5 @@
 import fancylog
+import logging
 
 lateral_separator = "**************"
 
@@ -20,3 +21,21 @@ def test_start_logging(tmp_path):
     assert lines[3].startswith("Output directory: ")
     assert lines[4].startswith("Current directory: ")
     assert lines[5].startswith("Version: ")
+
+
+def test_logger_name(tmp_path):
+    """
+    Quick check that expecter logger name is created
+    when specified.
+    """
+    logger_name = "hello_world"
+
+    # Logger name should not already exist
+    assert logger_name not in logging.root.manager.loggerDict.keys()
+
+    # Logger name should be created
+    fancylog.start_logging(tmp_path, fancylog, logger_name=logger_name)
+
+    assert logger_name in logging.root.manager.loggerDict.keys()
+
+


### PR DESCRIPTION
**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed? & What does this PR do?**

This PR adds a `logger_name` variable that lets the logger than fancylog sets up be given a name. This is useful
for grabbing this logger at a later time.

## How has this PR been tested?

Added new test to check expected `logger_name` is created.

Change is not breaking nor requires documentation change.

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality
- [ ] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
