### PR TITLE
Don't propagate named loggers.

### DIFF
--- a/fancylog/fancylog.py
+++ b/fancylog/fancylog.py
@@ -244,6 +244,7 @@ def initialise_logger(
     if logger_name:
         logger = logging.getLogger(logger_name)
         logger.handlers = []
+        logger.propagate = False
     else:
         logger = logging.getLogger()
 

--- a/tests/tests/test_general.py
+++ b/tests/tests/test_general.py
@@ -169,13 +169,14 @@ def test_named_logger_propagate(tmp_path, capsys):
     parent handlers. Root is always parent to named loggers.
     This means that named logger can still print to console
     through the root StreamHandler unless `propagate` is set
-    to `False`. Check here that
+    to `False`. Check here that propagate is set to False and
+    indeed named logger does not print to console.
     """
     logger_name = "hello_world"
 
     fancylog.start_logging(
         tmp_path, fancylog, logger_name=logger_name, log_to_console=False
-    )  # , log_to_console=False)
+    )
 
     logger = logging.getLogger(logger_name)
 

--- a/tests/tests/test_general.py
+++ b/tests/tests/test_general.py
@@ -163,7 +163,7 @@ def test_handlers_are_refreshed(tmp_path):
     assert logger.handlers == []
 
 
-def test_named_logger_propagate(tmp_path, capsys):
+def test_named_logger_doesnt_propagate(tmp_path, capsys):
     """
     By default, named loggers will propagate through
     parent handlers. Root is always parent to named loggers.


### PR DESCRIPTION
This PR sets `propagate=False` to any created name logger. Due to the insane way that python's logging module works it means that messages are printed to `stdout` even if `log_to_console=False`.  

This is because, as I understand it, all named loggers are created with `root` as their 'parent'. By default all child logger messages are propagated to their parent handlers. Therefore if the root logger is used, a `StreamHandler` is set on it and then the named logger starts logging to console. For example a MRE:

```
import logging

OUTPUT_FILEPATH = r"C:\Users\Joe\test_log1.log"

fh = logging.FileHandler(OUTPUT_FILEPATH, encoding="utf-8")
fh.setLevel("DEBUG")

logger = logging.getLogger("my_logger")
logger.setLevel("DEBUG")

logger.info("hello world 1")  # does not print to console as expected

# This seems to initialise a StreamHandler on the root
# logger, to which all child loggers are propagated to.
logging.info("log something on root")

logger.info("hello world 2")  # this is now printed to console
```

The tests are currently failing due to an issue with handlers that will be addressed in #33.