### PR TITLE
Handle multiprocessing for named loggers.

### DIFF
--- a/fancylog/fancylog.py
+++ b/fancylog/fancylog.py
@@ -290,7 +290,7 @@ def setup_logging(
     :param logger_name: If None, logger uses default logger. Otherwise,
         logger name is set to `logger_name`.
     """
-    initialise_logger(
+    logger = initialise_logger(
         filename,
         print_level=print_level,
         file_level=file_level,
@@ -302,20 +302,20 @@ def setup_logging(
             import multiprocessing_logging
 
             multiprocessing_logging.install_mp_handler()
-            logging.info("Starting logging")
-            logging.info(
+            logger.info("Starting logging")
+            logger.info(
                 "Multiprocessing-logging module found. Logging from all"
                 " processes"
             )
         except ModuleNotFoundError:
-            logging.info("Starting logging")
-            logging.info(
+            logger.info("Starting logging")
+            logger.info(
                 "Multiprocessing-logging module not found, not logging "
                 "multiple processes."
             )
     else:
-        logging.info("Starting logging")
-        logging.info("Not logging multiple processes")
+        logger.info("Starting logging")
+        logger.info("Not logging multiple processes")
 
 
 def disable_logging():

--- a/fancylog/fancylog.py
+++ b/fancylog/fancylog.py
@@ -298,18 +298,25 @@ def setup_logging(
         logger_name=logger_name,
     )
     if multiprocessing_aware:
+        if logger_name:
+            raise ValueError(
+                "`multiprocessing_aware` is not supported"
+                "with `logger_name`. Multiprocess logging"
+                "must be performed with the root logger."
+            )
+
         try:
             import multiprocessing_logging
 
             multiprocessing_logging.install_mp_handler()
-            logger.info("Starting logging")
-            logger.info(
+            logging.info("Starting logging")
+            logging.info(
                 "Multiprocessing-logging module found. Logging from all"
                 " processes"
             )
         except ModuleNotFoundError:
-            logger.info("Starting logging")
-            logger.info(
+            logging.info("Starting logging")
+            logging.info(
                 "Multiprocessing-logging module not found, not logging "
                 "multiple processes."
             )

--- a/tests/tests/test_general.py
+++ b/tests/tests/test_general.py
@@ -1,7 +1,6 @@
 import logging
 
 import pytest
-
 from rich.logging import RichHandler
 
 import fancylog
@@ -58,6 +57,7 @@ def test_assert_named_logger_with_multiprocessing(tmp_path):
         )
 
     assert "root logger" in str(e.value)
+
 
 def test_logging_to_console(tmp_path, capsys):
     """

--- a/tests/tests/test_general.py
+++ b/tests/tests/test_general.py
@@ -1,5 +1,7 @@
 import logging
 
+import pytest
+
 import fancylog
 
 lateral_separator = "**************"
@@ -38,3 +40,19 @@ def test_logger_name(tmp_path):
     fancylog.start_logging(tmp_path, fancylog, logger_name=logger_name)
 
     assert logger_name in logging.root.manager.loggerDict
+
+
+def test_assert_named_logger_with_multiprocessing(tmp_path):
+    """
+    Test an error is raised if trying to use multiprocess
+    logging with a named logger.
+    """
+    with pytest.raises(ValueError) as e:
+        fancylog.start_logging(
+            tmp_path,
+            fancylog,
+            logger_name="hello_world",
+            multiprocessing_aware=True,
+        )
+
+    assert "root logger" in str(e.value)


### PR DESCRIPTION
I realised in #30 multiprocess logging was not considered. It seems that [multiprocess-logging](https://pypi.org/project/multiprocessing-logging/) is only setup to work on the root logger. Therefore now if a named logger is requested with multiprocess logging an error is raised.

If multiprocessing is not raised, the startup logs are logged to the previously created logging (rather than root).

This adds a test to check the error is raised. I don't think any documentation is required.

@adamltyson I am not very familiar with multiprocess logging. Would it be hard to write a test for this?
