### PR TITLE
rename program to package

### DIFF
--- a/fancylog/fancylog.py
+++ b/fancylog/fancylog.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 import os
 import sys
+import warnings
 from datetime import datetime
 from importlib.util import find_spec
 
@@ -18,7 +19,7 @@ from fancylog.tools.git import (
 
 def start_logging(
     output_dir,
-    package,
+    package=None,
     variables=None,
     verbose=True,
     file_log_level="DEBUG",
@@ -33,6 +34,7 @@ def start_logging(
     log_to_console=True,
     timestamp=True,
     logger_name=None,
+    program=None,
 ):
     """Prepare the log file, and then begin logging.
 
@@ -73,6 +75,8 @@ def start_logging(
     logger_name
         If None, logger uses default logger; otherwise, logger
         name is set to `logger_name`.
+    program
+        Deprecated alias name for `package`.
 
     Returns
     -------
@@ -82,6 +86,21 @@ def start_logging(
     """
     output_dir = str(output_dir)
     print_log_level = "DEBUG" if verbose else "INFO"
+
+    if program:
+        warnings.warn(
+            "`program` is deprecated since 0.6.0 and will be "
+            "removed in 0.7.0; use `package` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        package = program
+
+    if not package:
+        raise ValueError(
+            "`package` or `program` (deprecated)` must be "
+            "passed to `start_logging()`."
+        )
 
     if log_to_file:
         if filename is None:

--- a/tests/tests/test_deprecations.py
+++ b/tests/tests/test_deprecations.py
@@ -1,0 +1,26 @@
+import pytest
+
+import fancylog
+
+
+def test_no_package_passed(tmp_path):
+    """
+    Test error is wrong if neither `package` or
+    `program` (deprecated) is raised.
+    """
+    with pytest.raises(ValueError) as e:
+        fancylog.start_logging(tmp_path)
+
+    assert "`package` or `program`" in str(e.value)
+
+
+def test_program_warning_shown(tmp_path):
+    """
+    Test depreciation warning is shown for `program`.
+    """
+    with pytest.warns(DeprecationWarning) as w:
+        fancylog.start_logging(tmp_path, program=fancylog)
+    assert (
+        "`program` is deprecated since 0.6.0 and will be removed in 0.7.0;"
+        in str(w[0].message)
+    )


### PR DESCRIPTION
I searched the LoggingHeader class and renamed variables named program to package. If there is more to this PR please let me know. Thanks!

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
-Currently the package variable is renamed to program when it is passed to LoggingHeader. It would make sense to rename this from program to package so that the naming is internally consistent.

**What does this PR do?**
-variables named "program" to "package"

## References

Please reference any existing issues/PRs that relate to this PR.

-issue #55 asks if program in LoggingHeader should be called package

