### PR TITLE
Docs: update README with multiprocessing installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ installed. The latter can be installed along with `fancylog` using:
 pip install fancylog[git]
 ```
 
+```bash
+pip install fancylog[multiprocessing]
+```
+
 #### To run example
 ```bash
 git clone https://github.com/neuroinformatics-unit/fancylog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dev = [
 
 git = ["gitpython"]
 
+multiprocessing = ["multiprocessing-logging"]
+
 [build-system]
 requires = [
     "setuptools>=45",


### PR DESCRIPTION
This PR updates the `README.md` to include installation instructions for the new
`multiprocessing` optional dependency.

### Motivation
The `fancylog` package now supports multiprocessing logging via the 
`multiprocessing-logging` package.  
Users should be able to easily discover how to install this extra dependency 
from the documentation.

### Changes
- Added a new section in the installation instructions showing how to install with:
  ```bash
  pip install fancylog[multiprocessing]