### PR TITLE
Change default, play around with benchmarking.

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          tox-args: "--override testenv.pass_env=GITHUB_ACTIONS"
 
   build_sdist_wheels:
     name: Build source distribution

--- a/tests/tests/test_benchmarks.py
+++ b/tests/tests/test_benchmarks.py
@@ -1,14 +1,8 @@
-import os
 import time
-
-import pytest
 
 import fancylog
 
 
-@pytest.mark.skipif(
-    not os.getenv("GITHUB_ACTIONS"), reason="`RUN_BENCHMARKS` was false`"
-)
 def test_benchmark(tmp_path, capsys):
     """
     A very rough benchmark to check for large regressions
@@ -16,9 +10,6 @@ def test_benchmark(tmp_path, capsys):
         Windows	test_benchmark	0.026
         Ubuntu	test_benchmark	0.024
         macOS	test_benchmark	0.0104
-
-    Only run in CI otherwise might fail on different systems as
-    the cutoff threshold is based on GitHub runners.
     """
     start_time = time.perf_counter()
 


### PR DESCRIPTION
`write_env_packages` includes subprocess calls which can be quite slow. This PR sets the default for this argument to `False` and adds some bencharking tests. 

The runtimes are below, as you can see when `True`,  setting up the logger takes much longer.
A rough benchmark test is added (only runs in CI) to check this benchmark runs in under 0.05s. This is pretty quick-and-dirty and might be brittle, @adamltyson  not sure if there is a better way to do this.

I also wanted to run this only in CI, because thats what the threshold is based on and so could easily fail running locally, but tox does not pass through environment variables by default. As such it is not possible to tell from inside the test whether we are in CI or not. I added `tox-args: "--override testenv.pass_env=GITHUB_ACTIONS` so that environment variable is passed through, but maybe handling this at the level of the NIU test action would be better.



| OS      | Test Case | write_env_packages | Time Taken (s)        | Result |
|---------|-----------|--------------------|------------------------|--------|
| Windows | test_benchmark | True  | 1.472| PASSED |
| Windows | test_benchmark | False | 0.026 | PASSED |
| Ubuntu  | test_benchmark | True  | 1.038| PASSED |
| Ubuntu  | test_benchmark | False | 0.024  | PASSED |
| macOS   | test_benchmark | True  | 0.707  | PASSED |
| macOS   | test_benchmark | False | 0.0104  | PASSED |

