### PR TITLE
Dont run CI on both pull request and push.

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -36,22 +36,12 @@ jobs:
           - os: windows-latest
             python-version: "3.13"
 
-  steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install .  # if needed
-
-    - name: Run pytest
-      run: pytest .
+    steps:
+      # Run tests
+      - uses: neuroinformatics-unit/actions/test@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   build_sdist_wheels:
     name: Build source distribution


### PR DESCRIPTION
On some PRs the tests were running twice, both under Pull Request and Push e.g. #80. This PR adjusts when these are run so they are only run on push to main (e.g. after a PR is merged) or on a PR, but not both. 

It also checks for `v*` on tag release, just in case you forget a leading `v` when making a release. I have done that before and it's a pain as the release gets pushed to PyPi without the `v` prefix.